### PR TITLE
improve error handling for Invoke-WebRequest

### DIFF
--- a/CheckMK.psm1
+++ b/CheckMK.psm1
@@ -137,11 +137,14 @@ function Invoke-CustomWebRequest {
     $BaseResponse = try {
         $PrimaryResponse = Invoke-WebRequest @PSBoundParameters
         $PrimaryResponse.BaseResponse
-    }
-    catch [System.Net.WebException] {
-        Write-Verbose "An exception was caught: $($_.Exception.Message)"
-        $_.Exception.Response # Nur BaseResponse bei Exceptions möglich
-    }
+        }
+        catch [System.Net.WebException] {
+            $ErrMessage =  $_.ErrorDetails.Message;
+            Write-Verbose "An exception was caught: $($_.Exception.Message)"
+            $ResponseErrorObj = $_.Exception.Response # Nur BaseResponse bei Exceptions möglich
+            Add-Member -InputObject $ResponseErrorObj -NotePropertyName ErrorMessage -NotePropertyValue $ErrMessage #add catched error message to $BaseResponse object
+            $ResponseErrorObj
+        }
     $ResponseHash = @{
         BaseResponse = $BaseResponse
         Response     = $PrimaryResponse
@@ -201,7 +204,7 @@ function Invoke-CMKApiCall {
     }
     else {
         # Nicht OK. Error Code lässt sich mit -verbose anzeigen.
-        return $false  #todo (Fehler werfen!, nicht false)
+        throw "StatusCode: $([int]($Response.BaseResponse.StatusCode)) StatusDescription: $($Response.BaseResponse.StatusDescription)`r`nMessage: `r`n$($Response.BaseResponse.ErrorMessage)"
     }
 }
 #endregion Connection


### PR DESCRIPTION
- get additional content: JSON message from checkmk containing detailed error message
- throw error with detailed message including JSON message instead of returning $false: function could now be handled with try-catch or similar

you get the details for a error message from checkmk.
example for New-CMKHost error if host already exists:
```
StatusCode: 400 StatusDescription: BAD REQUEST
Message:
{"title": "Bad Request", "status": 400, "detail": "These fields have problems: host_name", "fields": {"host_name": ["Host 'myserver.example' already exists."]}}
```