### PR TITLE
Funktion zum Starten der Service Discovery auf einem Host hinzugefügt

### DIFF
--- a/CheckMK.psm1
+++ b/CheckMK.psm1
@@ -853,6 +853,34 @@ function Get-CMKService {
         return Invoke-CMKApiCall -Method Get -Uri "/domain-types/service/collections/all$($QueryExtension)" -Connection $Connection -EndpointReturnsList
     }
 }
+function Invoke-CMKServiceDiscovery {
+    [CmdletBinding()]
+    param (
+        [parameter(Mandatory = $true, HelpMessage = 'Mit Get-CMKHost abgerufen')]
+        [string]
+        $HostName,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateSet('new','remove','fix_all','tabula_rasa','refresh','only_host_labels')]
+        [string]
+        $Mode = 'fix_all',
+    
+        [Parameter(Mandatory = $false, HelpMessage = 'Warten auf Beendigung der Service Discovery')]
+        [switch]
+        $WaitforCompletion,
+
+        [Parameter(Mandatory = $true)]
+        [object]
+        $Connection
+    )
+
+    $Body = @{
+        host_name = $HostName
+        mode = $Mode
+    } | ConvertTo-Json
+
+    return Invoke-CMKApiCall -Method Post -Uri '/domain-types/service_discovery_run/actions/start/invoke' -Body $Body -Connection $Connection
+}
 #endregion Services
 $ExportableFunctions = @(
     'Get-CMKConnection'
@@ -874,5 +902,6 @@ $ExportableFunctions = @(
     'Remove-CMKDowntime'
     'Get-CMKPendingChanges'
     'Get-CMKService'
+    'Invoke-CMKServiceDiscovery'
 )
 Export-ModuleMember -Function $ExportableFunctions

--- a/CheckMK.psm1
+++ b/CheckMK.psm1
@@ -864,10 +864,6 @@ function Invoke-CMKServiceDiscovery {
         [ValidateSet('new','remove','fix_all','tabula_rasa','refresh','only_host_labels')]
         [string]
         $Mode = 'fix_all',
-    
-        [Parameter(Mandatory = $false, HelpMessage = 'Warten auf Beendigung der Service Discovery')]
-        [switch]
-        $WaitforCompletion,
 
         [Parameter(Mandatory = $true)]
         [object]


### PR DESCRIPTION
Hi,

ich habe eine Funktion erstellt um die Service Discovery zu starten. Bei mir lief das mit meiner Instanz. Nach der Service Discovery und einem Aktiveren der Changes wurden die gefundenen Services gemonitored. Falls noch was ist gerne hinzufügen.