### PR TITLE
Downtime duration hinzugefügt

### DIFF
--- a/CheckMK.psm1
+++ b/CheckMK.psm1
@@ -853,6 +853,34 @@ function Get-CMKService {
         return Invoke-CMKApiCall -Method Get -Uri "/domain-types/service/collections/all$($QueryExtension)" -Connection $Connection -EndpointReturnsList
     }
 }
+function Invoke-CMKServiceDiscovery {
+    [CmdletBinding()]
+    param (
+        [parameter(Mandatory = $true, HelpMessage = 'Mit Get-CMKHost abgerufen')]
+        [string]
+        $HostName,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateSet('new','remove','fix_all','tabula_rasa','refresh','only_host_labels')]
+        [string]
+        $Mode = 'fix_all',
+    
+        [Parameter(Mandatory = $false, HelpMessage = 'Warten auf Beendigung der Service Discovery')]
+        [switch]
+        $WaitforCompletion,
+
+        [Parameter(Mandatory = $true)]
+        [object]
+        $Connection
+    )
+
+    $Body = @{
+        host_name = $HostName
+        mode = $Mode
+    } | ConvertTo-Json
+
+    return Invoke-CMKApiCall -Method Post -Uri '/domain-types/service_discovery_run/actions/start/invoke' -Body $Body -Connection $Connection
+}
 #endregion Services
 $ExportableFunctions = @(
     'Get-CMKConnection'
@@ -874,5 +902,6 @@ $ExportableFunctions = @(
     'Remove-CMKDowntime'
     'Get-CMKPendingChanges'
     'Get-CMKService'
+    'Invoke-CMKServiceDiscovery'
 )
 Export-ModuleMember -Function $ExportableFunctions

--- a/CheckMK.psm1
+++ b/CheckMK.psm1
@@ -665,7 +665,6 @@ function New-CMKDowntime {
     }
 
     Write-Verbose -Message $Downtime
-    Write-Verbose -Message $URI
 
     return Invoke-CMKApiCall -Method Post -Uri $URI -Body $Downtime -Connection $Connection
 }

--- a/CheckMK.psm1
+++ b/CheckMK.psm1
@@ -864,10 +864,6 @@ function Invoke-CMKServiceDiscovery {
         [ValidateSet('new','remove','fix_all','tabula_rasa','refresh','only_host_labels')]
         [string]
         $Mode = 'fix_all',
-    
-        [Parameter(Mandatory = $false, HelpMessage = 'Warten auf Beendigung der Service Discovery')]
-        [switch]
-        $WaitforCompletion,
 
         [Parameter(Mandatory = $true)]
         [object]


### PR DESCRIPTION
Hi,

ich habe die Option eine Downtime Duration anzugeben hinzugefügt. Der Übersichtlichkeit halber habe ich zudem die Parameter Sektion etwas anders formatiert. Das Enddatum wird zudem jetzt validiert. die CMK API antwortet auf Anfragen, in denen ein Enddatum vor dem aktuellen Zeitstempel oder auch vor dem Startdatum liegt mit einem 204 für erfolgreich. Die Downtime wird jedoch nicht angelegt. Das sollte von der Funktion jetzt entsprechend mit einem Fehler zurückgegeben werden um Missverständnisse zu vermeiden. 
Wenn der - Verbose Schalter bei der Funktion genutzt wird, wird die URI und der Body ausgegeben um die gesendeten Werte anzuzeigen, da CMK wie gesagt auch teilweise unsinnige Anfragen akzeptiert.